### PR TITLE
fix bug for using formatexpr

### DIFF
--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -201,8 +201,6 @@ function! clang_format#replace(line1, line2)
         let &l:selection = sel_save
         call setpos('.', pos_save)
     endtry
-
-    return 1
 endfunction
 " }}}
 


### PR DESCRIPTION
return 1 seems cause unexpected behavior when using formatexpr, so remove it
