### PR TITLE
Added ClangFormatAutoEnable and ClangFormatAutoDisable functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ It is more convenient to map `:ClangFormat` to your favorite key mapping in norm
 If you install [vim-operator-user](https://github.com/kana/vim-operator-user) in advance, you can also map `<Plug>(operator-clang-format)` to your favorite key bind.
 
 `:ClangFormatAutoToggle` command toggles the auto formatting on buffer write.
+`:ClangFormatAutoEnable` command enables the auto formatting on buffer write. Useful for automatically enabling the auto format through a vimrc. `:ClangFormatAutoDisable` turns it off.
 
 ### What is the difference from `clang-format.py`?
 
@@ -109,6 +110,11 @@ autocmd FileType c,cpp,objc vnoremap <buffer><Leader>cf :ClangFormat<CR>
 autocmd FileType c,cpp,objc map <buffer><Leader>x <Plug>(operator-clang-format)
 " Toggle auto formatting:
 nmap <Leader>C :ClangFormatAutoToggle<CR>
+```
+
+```vim
+" Enable auto formatting on c files:
+au FileType c ClangFormatAutoEnable
 ```
 
 ### For More Information

--- a/README.md
+++ b/README.md
@@ -112,8 +112,8 @@ autocmd FileType c,cpp,objc map <buffer><Leader>x <Plug>(operator-clang-format)
 nmap <Leader>C :ClangFormatAutoToggle<CR>
 ```
 
+##### Auto-enabling auto-formatting
 ```vim
-" Enable auto formatting on c files:
 au FileType c ClangFormatAutoEnable
 ```
 

--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -248,5 +248,15 @@ function! clang_format#toggle_auto_format()
     endif
 endfunction
 " }}}
+
+" enable auto formatting {{{
+function !clang_format#enable_auto_format()
+    let g:clang_format#auto_format = 1
+" }}}
+
+" disable auto formatting {{{
+function !clang_format#enable_auto_format()
+    let g:clang_format#auto_format = 0
+" }}}
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -252,11 +252,13 @@ endfunction
 " enable auto formatting {{{
 function! clang_format#enable_auto_format()
     let g:clang_format#auto_format = 1
+endfunction
 " }}}
 
 " disable auto formatting {{{
 function! clang_format#disable_auto_format()
     let g:clang_format#auto_format = 0
+endfunction
 " }}}
 let &cpo = s:save_cpo
 unlet s:save_cpo

--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -255,7 +255,7 @@ function !clang_format#enable_auto_format()
 " }}}
 
 " disable auto formatting {{{
-function !clang_format#enable_auto_format()
+function !clang_format#disable_auto_format()
     let g:clang_format#auto_format = 0
 " }}}
 let &cpo = s:save_cpo

--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -250,12 +250,12 @@ endfunction
 " }}}
 
 " enable auto formatting {{{
-function !clang_format#enable_auto_format()
+function! clang_format#enable_auto_format()
     let g:clang_format#auto_format = 1
 " }}}
 
 " disable auto formatting {{{
-function !clang_format#disable_auto_format()
+function! clang_format#disable_auto_format()
     let g:clang_format#auto_format = 0
 " }}}
 let &cpo = s:save_cpo

--- a/plugin/clang_format.vim
+++ b/plugin/clang_format.vim
@@ -20,5 +20,7 @@ augroup plugin-clang-format-auto-format
 augroup END
 
 command! ClangFormatAutoToggle call clang_format#toggle_auto_format()
+command! ClangFormatAutoEnable call clang_format#enable_auto_format()
+command! ClangFormatAutoDisable call clang_format#disable_auto_format()
 
 let g:loaded_clang_format = 1


### PR DESCRIPTION
I wanted to be able to have autoformatting be enabled all the time, fire-and-forget style. I don't know if there was a way to do it before, which I simply missed in my haste, but I added a way to do it.

This is the first time I've been doing any vim stuff, so I apologize if it's not up to standard. I'm up for changing it if it needs something more.