### PR TITLE
Issue #23 javascript support

### DIFF
--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -158,7 +158,7 @@ function! clang_format#format(line1, line2)
     else
         let args .= " -style=file "
     endif
-    let args .= printf("-assume-filename=%s", expand('%:p'))
+    let args .= printf("-assume-filename=%s", shellescape(expand('%:p')))
     let args .= g:clang_format#extra_args
     let clang_format = printf("%s %s --", g:clang_format#command, args)
     return s:system(clang_format, join(getline(1, '$'), "\n"))

--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -158,6 +158,7 @@ function! clang_format#format(line1, line2)
     else
         let args .= " -style=file "
     endif
+    let args .= printf("-assume-filename=%s", expand('%:p'))
     let args .= g:clang_format#extra_args
     let clang_format = printf("%s %s --", g:clang_format#command, args)
     return s:system(clang_format, join(getline(1, '$'), "\n"))

--- a/plugin/clang_format.vim
+++ b/plugin/clang_format.vim
@@ -14,9 +14,9 @@ command! -range=% -nargs=0 ClangFormatEchoFormattedCode echo clang_format#format
 
 augroup plugin-clang-format-auto-format
     autocmd!
-    autocmd BufWritePre * if &ft =~# '^\%(c\|cpp\|objc\)$' && g:clang_format#auto_format && !clang_format#is_invalid() | call clang_format#replace(1, line('$')) | endif
-    autocmd FileType c,cpp,objc if g:clang_format#auto_format_on_insert_leave && !clang_format#is_invalid() | call clang_format#enable_format_on_insert() | endif
-    autocmd FileType c,cpp,objc if g:clang_format#auto_formatexpr && !clang_format#is_invalid() | setlocal formatexpr=clang_format#replace(v:lnum,v:lnum+v:count-1) | endif
+    autocmd BufWritePre * if &ft =~# '^\%(c\|cpp\|objc\|javascript\)$' && g:clang_format#auto_format && !clang_format#is_invalid() | call clang_format#replace(1, line('$')) | endif
+    autocmd FileType c,cpp,objc,javascript if g:clang_format#auto_format_on_insert_leave && !clang_format#is_invalid() | call clang_format#enable_format_on_insert() | endif
+    autocmd FileType c,cpp,objc,javascript if g:clang_format#auto_formatexpr && !clang_format#is_invalid() | setlocal formatexpr=clang_format#replace(v:lnum,v:lnum+v:count-1) | endif
 augroup END
 
 command! ClangFormatAutoToggle call clang_format#toggle_auto_format()


### PR DESCRIPTION
I was having the same problem as issue #23. I have a .clang-format file and use the #detect_style_file option. I found that passing the filename with the -assume-filename option allowed clang-format to figure out the file type properly.

Side benefit, passing in the full path of the file allowed clang-format to pick the right configuration file.