### PR TITLE
Use -assume-filename command line argument only if Clang Format version is >= 3.8

### DIFF
--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -158,7 +158,10 @@ function! clang_format#format(line1, line2)
     else
         let args .= " -style=file "
     endif
-    let args .= printf("-assume-filename=%s ", shellescape(escape(expand('%:p'), " \t")))
+	let v = clang_format#get_version()
+	if (v[0] == 3 && v[1] >= 8) || v[0] > 3
+		let args .= printf("-assume-filename=%s ", shellescape(escape(expand('%:p'), " \t")))
+	endif
     let args .= g:clang_format#extra_args
     let clang_format = printf("%s %s --", g:clang_format#command, args)
     return s:system(clang_format, join(getline(1, '$'), "\n"))

--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -158,10 +158,10 @@ function! clang_format#format(line1, line2)
     else
         let args .= " -style=file "
     endif
-	let v = clang_format#get_version()
-	if (v[0] == 3 && v[1] >= 8) || v[0] > 3
-		let args .= printf("-assume-filename=%s ", shellescape(escape(expand('%:p'), " \t")))
-	endif
+    let v = clang_format#get_version()
+    if (v[0] == 3 && v[1] >= 8) || v[0] > 3
+      let args .= printf("-assume-filename=%s ", shellescape(escape(expand('%:p'), " \t")))
+    endif
     let args .= g:clang_format#extra_args
     let clang_format = printf("%s %s --", g:clang_format#command, args)
     return s:system(clang_format, join(getline(1, '$'), "\n"))


### PR DESCRIPTION
I'm using Clang 3.7.0 on Cygwin (compiled by myself) and it fails to find the .clang_format file when -assume-filename=<string> command line argument is used.

Since there's already a get_version() function to get Clang Format's version, we should only use arguments when supported by the current version.