### PR TITLE
Configuration filename does not depend of the OS

### DIFF
--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -166,8 +166,7 @@ let g:clang_format#auto_formatexpr = s:getg('clang_format#auto_formatexpr', 0)
 " format codes {{{
 function! s:detect_style_file()
     let dirname = fnameescape(expand('%:p:h'))
-    let style_file_name = has('win32') || has('win64') ? '_clang-format' : '.clang-format'
-    return findfile(style_file_name, dirname.';') != ''
+    return findfile('.clang-format', dirname.';') != '' || findfile('_clang-format', dirname.';') != ''
 endfunction
 
 function! clang_format#format(line1, line2)


### PR DESCRIPTION
Recently this plugin stopped working for me, and yet I did not made any updates of this plugin, or clang-format. I then found out that a deleted an unused `.clang-format` file located in my home directory (I use linux).

I have a lot of projects that have a `_clang-format` file at their root, in git. And until recently, all worked well, because this plugin detected that I had indeed a configuration file (it thought it was the `.clang-format` in my home), and went ahead. Then clang-format did its job and used the `_clang-format` file as it should. But now that I have only some `_clang-format` files in my filesystem, and this plugin decides that, since I am not on Windows, that do not matter.

But they do! One can use either `.clang-format` or `_clang-format` on any OS. See http://clang.llvm.org/docs/ClangFormat.html