### PR TITLE
Fixed a bug caused by paths with spaces in Windows.

### DIFF
--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -109,7 +109,11 @@ endfunction
 
 function! clang_format#is_invalid()
     if !exists('s:command_available')
-        if ! executable(g:clang_format#command)
+	    " if running on windows and the path has spaces it needs to be quoted,
+		" but executable() get confused by the quotes, so we remove them
+	    if has("win32") && !executable(split(g:clang_format#command, '"')[0])
+		    return 1
+        elseif !has("win32")  && !executable(g:clang_format#command)
             return 1
         endif
         let s:command_available = 1


### PR DESCRIPTION
If I specify
g:clang_format='"C:/Program Files (x86)/LLVM/bin/clang-format.exe"' (For example)
then the call to executable() fails because the executable function gets confused by the quotes, which
are necessary to escape the spaces.
This patch removes those quotes before testing if it is executable.