### PR TITLE
create new undo block for formatting (fix #30)

### DIFF
--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -235,7 +235,7 @@ function! clang_format#replace(line1, line2)
                 " Create a new undo block to separate all formatting related
                 " changes from the last undo block but still preserve original
                 " cursor position (issue #30).
-                silent execute "normal! ii\<esc>\"_x"
+                silent execute "noautocmd normal! ii\<esc>\"_x"
 
                 call setreg('g', formatted[i+1:], 'V')
                 undojoin | silent normal! 2gg"_dG

--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -232,6 +232,11 @@ function! clang_format#replace(line1, line2)
                     throw 'fallback'
                 endif
 
+                " Create a new undo block to separate all formatting related
+                " changes from the last undo block but still preserve original
+                " cursor position (issue #30).
+                silent normal! i new undo block
+
                 call setreg('g', formatted[i+1:], 'V')
                 undojoin | silent normal! 2gg"_dG
                 silent put g

--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -235,7 +235,7 @@ function! clang_format#replace(line1, line2)
                 " Create a new undo block to separate all formatting related
                 " changes from the last undo block but still preserve original
                 " cursor position (issue #30).
-                silent execute "normal! ii\<esc>x"
+                silent execute "normal! ii\<esc>\"_x"
 
                 call setreg('g', formatted[i+1:], 'V')
                 undojoin | silent normal! 2gg"_dG

--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -235,7 +235,7 @@ function! clang_format#replace(line1, line2)
                 " Create a new undo block to separate all formatting related
                 " changes from the last undo block but still preserve original
                 " cursor position (issue #30).
-                silent normal! i new undo block
+                silent execute "normal! ii\<esc>x"
 
                 call setreg('g', formatted[i+1:], 'V')
                 undojoin | silent normal! 2gg"_dG


### PR DESCRIPTION
This PR creates  a new undo block to separate formatting related changes from the last undo block. The proposed solution in #30 (to simply remove the undojoin) does not respect the old cursor position. Thus a new undo block is created to store the current cursor position.