### PR TITLE
Restore unnamed register after format

### DIFF
--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -209,7 +209,7 @@ function! clang_format#replace(line1, line2)
     let sel_save = &l:selection
     let &l:selection = 'inclusive'
     let [save_g_reg, save_g_regtype] = [getreg('g'), getregtype('g')]
-    let [save_unnamed_reg, save_unnamed_regtype] = [getreg(''), getregtype('')]
+    let [save_unnamed_reg, save_unnamed_regtype] = [getreg(v:register), getregtype(v:register)]
 
     try
         let formatted = clang_format#format(a:line1, a:line2)
@@ -220,7 +220,7 @@ function! clang_format#replace(line1, line2)
             call s:error_message(formatted)
         endif
     finally
-        call setreg('', save_unnamed_reg, save_unnamed_regtype)
+        call setreg(v:register, save_unnamed_reg, save_unnamed_regtype)
         call setreg('g', save_g_reg, save_g_regtype)
         let &l:selection = sel_save
         call setpos('.', pos_save)

--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -209,6 +209,7 @@ function! clang_format#replace(line1, line2)
     let sel_save = &l:selection
     let &l:selection = 'inclusive'
     let [save_g_reg, save_g_regtype] = [getreg('g'), getregtype('g')]
+    let [save_unnamed_reg, save_unnamed_regtype] = [getreg(''), getregtype('')]
 
     try
         let formatted = clang_format#format(a:line1, a:line2)
@@ -219,6 +220,7 @@ function! clang_format#replace(line1, line2)
             call s:error_message(formatted)
         endif
     finally
+        call setreg('', save_unnamed_reg, save_unnamed_regtype)
         call setreg('g', save_g_reg, save_g_regtype)
         let &l:selection = sel_save
         call setpos('.', pos_save)


### PR DESCRIPTION
Replacing a visual selection with the formatted lines (ggVG"gp),
puts in the unnamed register the selections.

This commit restores the previously held value of the unnamed register
after applying the formatting.