### PR TITLE
Added Arduino support

### DIFF
--- a/plugin/clang_format.vim
+++ b/plugin/clang_format.vim
@@ -19,17 +19,17 @@ command! -range=% -nargs=0 ClangFormatEchoFormattedCode echo clang_format#format
 augroup plugin-clang-format-auto-format
     autocmd!
     autocmd BufWritePre *
-        \ if &ft =~# '^\%(c\|cpp\|objc\|java\|javascript\|typescript\|proto\)$' &&
+        \ if &ft =~# '^\%(c\|cpp\|objc\|java\|javascript\|typescript\|proto\|arduino\)$' &&
         \     g:clang_format#auto_format &&
         \     !clang_format#is_invalid() |
         \     call clang_format#replace(1, line('$')) |
         \ endif
-    autocmd FileType c,cpp,objc,java,javascript,typescript,proto
+    autocmd FileType c,cpp,objc,java,javascript,typescript,proto,arduino
         \ if g:clang_format#auto_format_on_insert_leave &&
         \     !clang_format#is_invalid() |
         \     call clang_format#enable_format_on_insert() |
         \ endif
-    autocmd FileType c,cpp,objc,java,javascript,typescript,proto
+    autocmd FileType c,cpp,objc,java,javascript,typescript,proto,arduino
         \ if g:clang_format#auto_formatexpr &&
         \     !clang_format#is_invalid() |
         \     setlocal formatexpr=clang_format#replace(v:lnum,v:lnum+v:count-1) |


### PR DESCRIPTION
Arduino's language has been supported by vim (ft=arduino) for a while (3+ years) and it's pretty much plain C++.
Users should be able to use ClangFormat to format it.