### PR TITLE
Fixing Windows error while running without a .clang-format.

### DIFF
--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -64,7 +64,7 @@ endfunction
 
 function! s:make_style_options() abort
     let extra_options = s:build_extra_options()
-    return printf("'{BasedOnStyle: %s, IndentWidth: %d, UseTab: %s%s}'",
+    return printf("\"{BasedOnStyle: %s, IndentWidth: %d, UseTab: %s%s}\"",
                         \ g:clang_format#code_style,
                         \ (exists('*shiftwidth') ? shiftwidth() : &l:shiftwidth),
                         \ &l:expandtab==1 ? 'false' : 'true',

--- a/t/clang_format_spec.vim
+++ b/t/clang_format_spec.vim
@@ -35,7 +35,7 @@ function! GetBuffer() abort
 endfunction
 
 function! ClangFormat(line1, line2, ...) abort
-    let opt = printf("-lines=%d:%d -style='{BasedOnStyle: Google, IndentWidth: %d, UseTab: %s", a:line1, a:line2, &l:shiftwidth, &l:expandtab==1 ? "false" : "true")
+    let opt = printf("-lines=%d:%d -style=\"{BasedOnStyle: Google, IndentWidth: %d, UseTab: %s", a:line1, a:line2, &l:shiftwidth, &l:expandtab==1 ? "false" : "true")
     let file = 'test.cpp'
 
     for a in a:000
@@ -45,7 +45,7 @@ function! ClangFormat(line1, line2, ...) abort
             let opt .= a
         endif
     endfor
-    let opt .= "}'"
+    let opt .= "}\""
 
     let cmd = printf('%s %s ./%st/%s --', g:clang_format#command, opt, s:root_dir, file)
     let result = Chomp(system(cmd))


### PR DESCRIPTION
needed to change single quotes to double quotes.

This addresses #14