### PR TITLE
escaping -style

### DIFF
--- a/t/clang_format_spec.vim
+++ b/t/clang_format_spec.vim
@@ -35,7 +35,7 @@ function! GetBuffer() abort
 endfunction
 
 function! ClangFormat(line1, line2, ...) abort
-    let opt = printf("-lines=%d:%d -style='{BasedOnStyle: Google, IndentWidth: %d, UseTab: %s", a:line1, a:line2, &l:shiftwidth, &l:expandtab==1 ? "false" : "true")
+    let opt = printf("-lines=%d:%d '-style={BasedOnStyle: Google, IndentWidth: %d, UseTab: %s", a:line1, a:line2, &l:shiftwidth, &l:expandtab==1 ? "false" : "true")
     let file = 'test.cpp'
 
     for a in a:000


### PR DESCRIPTION
This fixes following error on Windows when .clang-format is not found:

error: -offset, -length and -lines can only be used for single file.

Also added undocumented feature - g:clang_format#enable_fallback_style for those who do not want any auto-formatting from clang if .clang-format is not found.