### PR TITLE
Don't delete legitimate newline(s) at the beginning of the file

### DIFF
--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -236,7 +236,7 @@ function! clang_format#replace(line1, line2, ...) abort
     endif
 
     let winview = winsaveview()
-    let splitted = split(formatted, '\n')
+    let splitted = split(formatted, '\n', 1)
 
     silent! undojoin
     if line('$') > len(splitted)


### PR DESCRIPTION
clang-format does not have the rule of removing the newline(s) at the beginning of the file but splitting by newline character without setting the 'keepempty' flag could delete the newline(s) implicitly. The fix is necessary when the users want to intentionally put newline(s) at the beginning of their files, like:
`<newline>`
`/**`
` * my file`
`*/`
`....`

From Vim documentation:
> split({expr} [, {pattern} [, {keepempty}]])			*split()*
		When the first or last item is empty it is omitted, unless the
		{keepempty} argument is given and it's non-zero.
...
		Splitting a table where the first element can be empty:
			:let items = split(line, ':', 1)
 		The opposite function is |join()|.

