### PR TITLE
Fix clearing wrong autocmds

### DIFF
--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -262,7 +262,7 @@ endfunction
 
 function! clang_format#enable_format_on_insert() abort
     augroup plugin-clang-format-auto-format-insert
-        autocmd!
+        autocmd! * <buffer>
         autocmd InsertEnter <buffer> let s:pos_on_insertenter = getpos('.')
         autocmd InsertLeave <buffer> call s:format_inserted_area()
     augroup END


### PR DESCRIPTION
Previous to this fix, enabling autoformat-on-insert-leave for one buffer
disables it for any other buffer that had it set.  With this change
enabling autoformat-on-insert-leave only impacts the buffer for which
it is being run.