### PR TITLE
Add support for filetype vala (#97)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,12 @@ Currently below languages are supported:
 
 - C
 - C++
-- Objective-C
-- JavaScript
 - Java
-- TypeScript
+- JavaScript
+- Objective-C
 - Protobuf
+- TypeScript
+- Vala
 
 ## Screenshot
 
@@ -105,9 +106,9 @@ Formatting is executed on `InsertLeave` event.
 
 - `g:clang_format#auto_formatexpr`
 
-When the value is 1, `formatexpr` option is set by vim-clang-format automatically in C, C++ and ObjC codes.
+When the value is 1, `formatexpr` option is set by vim-clang-format automatically in any supported `filetype`.
 Vim's format mappings (e.g. `gq`) get to use `clang-format` to format. This
-option is not comptabile with Vim's `textwidth` feature. You must set
+option is not compatible with Vim's `textwidth` feature. You must set
 `textwidth` to `0` when the `formatexpr` is set.
 
 - `g:clang_format#enable_fallback_style`

--- a/doc/clang-format.txt
+++ b/doc/clang-format.txt
@@ -22,14 +22,15 @@ INTRODUCTION                                     *vim-clang-format-introduction*
 *vim-clang-format* formats your C, C++ and Objective-C code with specific coding
 style using clang.  Following filetypes are supported.
 
+* arduino
 * c
 * cpp
-* objc
-* javascript
 * java
-* typescript
+* javascript
+* objc
 * proto
-* arduino
+* typescript
+* vala
 
 Screenshot:
 http://gifzo.net/BIteGJ9Vasg.gif
@@ -194,10 +195,11 @@ g:clang_format#auto_format_on_insert_leave
 
 g:clang_format#auto_formatexpr		        *g:clang_format#auto_formatexpr*
 
-    When the value is 1, 'formatexpr' option is set automatically in |c|, |cpp|
-    and |objc| codes.  Vim's format mappings (e.g. |gq|) get to use |clang-format|
-    to format. This option is not comptabile with Vim's `textwidth` feature. You
-    must set `textwidth` to `0` when the `formatexpr` is set.
+    When the value is 1, 'formatexpr' option is set automatically in any
+    supported |filetype|.  Vim's format mappings (e.g. |gq|) get to use
+    |clang-format| to format. This option is not compatible with Vim's
+    `textwidth` feature. You must set `textwidth` to `0` when the `formatexpr`
+    is set.
 
 g:clang_format#enable_fallback_style	  *g:clang_format#enable_fallback_style*
 

--- a/plugin/clang_format.vim
+++ b/plugin/clang_format.vim
@@ -19,17 +19,17 @@ command! -range=% -nargs=0 ClangFormatEchoFormattedCode echo clang_format#format
 augroup plugin-clang-format-auto-format
     autocmd!
     autocmd BufWritePre *
-        \ if &ft =~# '^\%(c\|cpp\|objc\|java\|javascript\|typescript\|proto\|arduino\)$' &&
+        \ if &ft =~# '^\%(c\|cpp\|objc\|java\|javascript\|typescript\|proto\|arduino\|vala\)$' &&
         \     g:clang_format#auto_format &&
         \     !clang_format#is_invalid() |
         \     call clang_format#replace(1, line('$')) |
         \ endif
-    autocmd FileType c,cpp,objc,java,javascript,typescript,proto,arduino
+    autocmd FileType c,cpp,objc,java,javascript,typescript,proto,arduino,vala
         \ if g:clang_format#auto_format_on_insert_leave &&
         \     !clang_format#is_invalid() |
         \     call clang_format#enable_format_on_insert() |
         \ endif
-    autocmd FileType c,cpp,objc,java,javascript,typescript,proto,arduino
+    autocmd FileType c,cpp,objc,java,javascript,typescript,proto,arduino,vala
         \ if g:clang_format#auto_formatexpr &&
         \     !clang_format#is_invalid() |
         \     setlocal formatexpr=clang_format#replace(v:lnum,v:lnum+v:count-1) |


### PR DESCRIPTION
Using for example arrufat/vala.vim[1] as filetype detector of the gnome
project vala files. Should be possible to use clang-format for those
types of files.

[1]: https://github.com/arrufat/vala.vim