### PR TITLE
Allow Configuration of Autocommand File Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Format your C family code
 
 This plugin formats your code with specific coding style using [clang-format](http://clang.llvm.org/docs/ClangFormat.html).
 
-Currently below languages are supported:
+Automatic formatting is provided for the following languages by default:
 
 - C
 - C++
@@ -109,6 +109,12 @@ When the value is 1, `formatexpr` option is set by vim-clang-format automaticall
 Vim's format mappings (e.g. `gq`) get to use `clang-format` to format. This
 option is not comptabile with Vim's `textwidth` feature. You must set
 `textwidth` to `0` when the `formatexpr` is set.
+
+- `g:clang_format#auto_filetypes`
+
+List of file types to which `g:clang_format#auto_format`, `g:clang_format#auto_format_on_insert_leave`,
+and `g:clang_format#auto_formatexpr` should be applied.
+The default value is `["c", "cpp", "objc", "java", "javascript", "proto", "arduino"]`.
 
 - `g:clang_format#enable_fallback_style`
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ In particular, the following link is useful to know the information of a key and
 
     The MIT License (MIT)
 
-    Copyright (c) 2013 rhysd
+    Copyright (c) 2013-2021 rhysd
 
     Permission is hereby granted, free of charge, to any person obtaining a copy
     of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ option is not comptabile with Vim's `textwidth` feature. You must set
 
 List of file types to which `g:clang_format#auto_format`, `g:clang_format#auto_format_on_insert_leave`,
 and `g:clang_format#auto_formatexpr` should be applied.
-The default value is `["c", "cpp", "objc", "java", "javascript", "proto", "arduino"]`.
+The default value is `["c", "cpp", "objc", "java", "javascript", "typescript", "proto", "arduino"]`.
 
 - `g:clang_format#enable_fallback_style`
 

--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -195,6 +195,9 @@ let g:clang_format#enable_fallback_style = s:getg('clang_format#enable_fallback_
 let g:clang_format#auto_format = s:getg('clang_format#auto_format', 0)
 let g:clang_format#auto_format_on_insert_leave = s:getg('clang_format#auto_format_on_insert_leave', 0)
 let g:clang_format#auto_formatexpr = s:getg('clang_format#auto_formatexpr', 0)
+let g:clang_format#auto_filetypes = s:getg( 'clang_format#auto_filetypes',
+                                          \ [ 'c', 'cpp', 'objc', 'java', 'javascript',
+                                          \   'typescript', 'proto', 'arduino' ] )
 " }}}
 
 " format codes {{{

--- a/doc/clang-format.txt
+++ b/doc/clang-format.txt
@@ -256,7 +256,7 @@ LICENSE                                               *vim-clang-format-license*
 
 |vim-clang-format| is distributed under MIT license.
 
-  Copyright (c) 2013-2017 rhysd
+  Copyright (c) 2013-2021 rhysd
 
   Permission is hereby granted, free of charge, to any person obtaining
   a copy of this software and associated documentation files (the

--- a/doc/clang-format.txt
+++ b/doc/clang-format.txt
@@ -206,7 +206,7 @@ g:clang_format#auto_filetypes                    *g:clang_format#auto_filetypes*
     |g:clang_format#auto_format_on_insert_leave|, and
     |g:clang_format#auto_formatexpr| should be applied.
     The default value is [ "c", "cpp", "objc", "java",
-                         \ "javascript", "proto", "arduino" ].
+                         \ "javascript", "typescript", "proto", "arduino" ].
 
 g:clang_format#enable_fallback_style	  *g:clang_format#enable_fallback_style*
 

--- a/doc/clang-format.txt
+++ b/doc/clang-format.txt
@@ -20,7 +20,8 @@ License          |vim-clang-format-license|
 INTRODUCTION                                     *vim-clang-format-introduction*
 
 *vim-clang-format* formats your C, C++ and Objective-C code with specific coding
-style using clang.  Following filetypes are supported.
+style using clang.  Automatic formatting is supported for the following file
+types by default.
 
 * c
 * cpp
@@ -198,6 +199,14 @@ g:clang_format#auto_formatexpr		        *g:clang_format#auto_formatexpr*
     and |objc| codes.  Vim's format mappings (e.g. |gq|) get to use |clang-format|
     to format. This option is not comptabile with Vim's `textwidth` feature. You
     must set `textwidth` to `0` when the `formatexpr` is set.
+
+g:clang_format#auto_filetypes                    *g:clang_format#auto_filetypes*
+
+    List of file types to which |g:clang_format#auto_format|,
+    |g:clang_format#auto_format_on_insert_leave|, and
+    |g:clang_format#auto_formatexpr| should be applied.
+    The default value is [ "c", "cpp", "objc", "java",
+                         \ "javascript", "proto", "arduino" ].
 
 g:clang_format#enable_fallback_style	  *g:clang_format#enable_fallback_style*
 

--- a/plugin/clang_format.vim
+++ b/plugin/clang_format.vim
@@ -19,18 +19,20 @@ command! -range=% -nargs=0 ClangFormatEchoFormattedCode echo clang_format#format
 augroup plugin-clang-format-auto-format
     autocmd!
     autocmd BufWritePre *
-        \ if &ft =~# '^\%(c\|cpp\|objc\|java\|javascript\|typescript\|proto\|arduino\)$' &&
+        \ if &ft =~# '^\%('.join(g:clang_format#auto_filetypes,'\|').'\)$' &&
         \     g:clang_format#auto_format &&
         \     !clang_format#is_invalid() |
         \     call clang_format#replace(1, line('$')) |
         \ endif
-    autocmd FileType c,cpp,objc,java,javascript,typescript,proto,arduino
-        \ if g:clang_format#auto_format_on_insert_leave &&
+    autocmd FileType *
+        \ if &ft =~# '^\%('.join(g:clang_format#auto_filetypes,'\|').'\)$' &&
+        \     g:clang_format#auto_format_on_insert_leave &&
         \     !clang_format#is_invalid() |
         \     call clang_format#enable_format_on_insert() |
         \ endif
-    autocmd FileType c,cpp,objc,java,javascript,typescript,proto,arduino
-        \ if g:clang_format#auto_formatexpr &&
+    autocmd FileType *
+        \ if &ft =~# '^\%('.join(g:clang_format#auto_filetypes,'\|').'\)$' &&
+        \     g:clang_format#auto_formatexpr &&
         \     !clang_format#is_invalid() |
         \     setlocal formatexpr=clang_format#replace(v:lnum,v:lnum+v:count-1) |
         \ endif


### PR DESCRIPTION
This update introduces a new global variables `g:clang_format#auto_filetypes`, which allows the user to define the list of file types to which `g:clang_format#auto_format`, `g:clang_format#auto_format_on_insert_leave`,
and `g:clang_format#auto_formatexpr` should be applied.

The default value for this variable is `["c", "cpp", "objc", "java", "javascript", "proto", "arduino"]`, matching preexisting behavior for the plugin.