### PR TITLE
Add git_diff behavior

### DIFF
--- a/doc/clang-format.txt
+++ b/doc/clang-format.txt
@@ -127,6 +127,11 @@ g:clang_format#command                                  *g:clang_format#command*
     Name of clang-format command.
     The default value is "clang-format".
 
+g:clang_format#git                                          *g:clang_format#git*
+
+    Name of the git command.
+    The default value is "git".
+
 g:clang_format#code_style                            *g:clang_format#code_style*
 
     Base coding style for formatting.  Available coding styles are "llvm",
@@ -185,6 +190,25 @@ g:clang_format#auto_format                          *g:clang_format#auto_format*
     When the value is 1, |vim-clang-format| automatically formats a current
     buffer on saving the buffer.  Formatting is executed at |BufWritePre| event.
     The default value is 0.
+
+g:clang_format#auto_format_git_diff        *g:clang_format#auto_format_git_diff*
+
+    When this value is 1, and when g:clang_format#auto_format is 1, the auto
+    format only formats modified lines is the file is tracked in git.
+    If the file is not tracked, or even not in a git project, fallback
+    behavior depends on |g:clang_format#auto_format_git_diff_fallback|.
+    WARNING: this option should not be used with
+    |g:clang_format#auto_format_on_insert_leave|.
+    The default value is 0.
+
+g:clang_format#auto_format_git_diff_fallback
+                                  *g:clang_format#auto_format_git_diff_fallback*
+
+    Fallback behavior when |g:clang_format#auto_format_git_diff| is 1 and the
+    current file is not tracked. The value can be:
+    - 'file': the whole file is formatted (which is the default
+      |g:clang_format#auto_format| behavior).
+    - 'pass': the file is not formatted.
 
 g:clang_format#auto_format_on_insert_leave
                                     *g:clang_format#auto_format_on_insert_leave*

--- a/plugin/clang_format.vim
+++ b/plugin/clang_format.vim
@@ -22,7 +22,7 @@ augroup plugin-clang-format-auto-format
         \ if &ft =~# '^\%(c\|cpp\|objc\|java\|javascript\|typescript\|proto\|arduino\)$' &&
         \     g:clang_format#auto_format &&
         \     !clang_format#is_invalid() |
-        \     call clang_format#replace(1, line('$')) |
+        \     call clang_format#do_auto_format() |
         \ endif
     autocmd FileType c,cpp,objc,java,javascript,typescript,proto,arduino
         \ if g:clang_format#auto_format_on_insert_leave &&


### PR DESCRIPTION
Hello,

I am deploying the use of clang format in my team, and I am doing some experiments to use this tool, especially in editors.

Your addon is really great, but format the whole file could easily lead to unrelated diffs in some commits. Your option InsertLeave is actually ingenous, but depending on user movement it still could lead to large part of file reformating.

An easy way would be to integrate or mimic the tool clang-format-diff, and only format git diff chunks in the edited file.

This PR is still a work in progress, especially around the git integration and the possible options (for example, what to do in case of untracked file, fallback to whole file format or not). And no tests have been wrtten for the moment.
But I think it fits right in your system.

What do you think about this feature?