### PR TITLE
Fix clang_format#replace function

### DIFF
--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -272,7 +272,7 @@ function! clang_format#replace_ranges(ranges, ...) abort
 endfunction
 
 function! clang_format#replace(line1, line2, ...) abort
-    call call(function("clang_format#replace_ranges"), [[line1, line2]], a:000)
+    call call(function("clang_format#replace_ranges"), [[[a:line1, a:line2]], a:000])
 endfunction
 " }}}
 


### PR DESCRIPTION
During clang_format#replace_ranges conversion, a bug has been introduced
in clang_format#replace function, which completly broke it.

This patch aims to fix this bug.