### PR TITLE
Specify ContinuationIndentWidth as 2*IndentWidth

### DIFF
--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -80,6 +80,7 @@ function! s:make_style_options() abort
                         \ g:clang_format#code_style,
                         \ indentwidth,
                         \ indentwidth * 2,
+                        \ &l:expandtab==1 ? 'false' : 'true',
                         \ extra_options)
 endfunction
 

--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -75,10 +75,11 @@ endfunction
 
 function! s:make_style_options() abort
     let extra_options = s:build_extra_options()
-    return printf("{BasedOnStyle: %s, IndentWidth: %d, UseTab: %s%s}",
+    let indentwidth = exists('*shiftwidth') ? shiftwidth() : &l:shiftwidth
+    return printf("{BasedOnStyle: %s, IndentWidth: %d, ContinuationIndentWidth: %d, UseTab: %s%s}",
                         \ g:clang_format#code_style,
-                        \ (exists('*shiftwidth') ? shiftwidth() : &l:shiftwidth),
-                        \ &l:expandtab==1 ? 'false' : 'true',
+                        \ indentwidth,
+                        \ indentwidth * 2,
                         \ extra_options)
 endfunction
 


### PR DESCRIPTION
Most styles use ContinuationIndentWidth = 2*IndentWidth (google, llvm, etc). With existing arguments, shiftwidth=4 gives
```cpp
constexpr operator To() const
    noexcept(noexcept(static_cast≺To≻(ːdeclval≺From≻()))) ⇉
    return static_cast≺To≻(val)
```
instead of expected
```cpp
constexpr operator To() const
        noexcept(noexcept(static_cast≺To≻(ːdeclval≺From≻()))) ⇉
    return static_cast≺To≻(val)
```