### PR TITLE
Add option to skip version check

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,12 @@ Name of `clang-format`. If the name of command is not `clang-format`
 or you want to specify a command by absolute path, set this variable.
 Default value is `clang-format`.
 
+- `g:clang_format#check_version`
+
+If set to `0` the version of `clang-format` will not be checked. This is useful if a wrapper
+script is in use that doesn't correctly report the `clang-format` version.
+Default value is `1`.
+
 - `g:clang_format#extra_args`
 
 You can specify more extra options in `g:clang_format#extra_args` as String or List of String.

--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -133,6 +133,9 @@ function! clang_format#is_invalid() abort
             " XXX: Give up checking version
             return 0
         endif
+        if g:clang_format#check_version == 0
+            return 0
+        endif
         if v[0] < 3 || (v[0] == 3 && v[1] < 4)
             return 2
         endif
@@ -188,6 +191,7 @@ function! s:getg(name, default) abort
 endfunction
 
 let g:clang_format#command = s:getg('clang_format#command', 'clang-format')
+let g:clang_format#check_version = s:getg('clang_format#check_version', 1)
 let g:clang_format#extra_args = s:getg('clang_format#extra_args', "")
 if type(g:clang_format#extra_args) == type([])
     let g:clang_format#extra_args = join(g:clang_format#extra_args, " ")

--- a/doc/clang-format.txt
+++ b/doc/clang-format.txt
@@ -128,6 +128,13 @@ g:clang_format#command                                  *g:clang_format#command*
     Name of clang-format command.
     The default value is "clang-format".
 
+g:clang_format#check_version                      *g:clang_format#check_version*
+
+    If set to `0` the version of `clang-format` will not be checked. This is
+    useful if a wrapper script is in use that doesn't correctly report the
+    `clang-format` version.
+    Default value is `1`.
+
 g:clang_format#git                                          *g:clang_format#git*
 
     Name of the git command.


### PR DESCRIPTION
Adds an option to skip the clang-format version check. This is useful if a wrapper script is being used for clang-format which doesn't report the underlying clang-format version