### PR TITLE
Stop setting the use of tabs automatically, as it interfers with using UseTab: ForIndentation

### DIFF
--- a/autoload/clang_format.vim
+++ b/autoload/clang_format.vim
@@ -75,10 +75,9 @@ endfunction
 
 function! s:make_style_options() abort
     let extra_options = s:build_extra_options()
-    return printf("{BasedOnStyle: %s, IndentWidth: %d, UseTab: %s%s}",
+    return printf("{BasedOnStyle: %s, IndentWidth: %d%s}",
                         \ g:clang_format#code_style,
                         \ (exists('*shiftwidth') ? shiftwidth() : &l:shiftwidth),
-                        \ &l:expandtab==1 ? 'false' : 'true',
                         \ extra_options)
 endfunction
 


### PR DESCRIPTION
At this moment, using `"UseTab": "ForIndentation"` in the config file results in clang-format refusing to work, because it will always conflict with the automatically set `UseTab` which is either `false` or `true`. This is not a usable state for me, so I’d like for this to be removed entirely and be left in the hands of the user, as it used to be.
